### PR TITLE
Update for latest nightly and serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,11 @@ categories = ["encoding", "no-std"]
 travis-ci = { repository = "KodrAus/serde_fmt" }
 
 [features]
-default = ["std"]
-
 # Support the standard library
 std = ["serde/std"]
 
 [dependencies.serde]
-version = "1"
+version = "1.0.104"
 default-features = false
 
 [dev-dependencies.serde_derive]

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -2,5 +2,5 @@
 
 set -o errexit -o nounset
 
-cargo build
+cargo test
 cargo test --features std

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -2,4 +2,5 @@
 
 set -o errexit -o nounset
 
-cargo test
+cargo build
+cargo test --features std

--- a/ci/thumbv6m.sh
+++ b/ci/thumbv6m.sh
@@ -4,4 +4,4 @@ set -o errexit -o nounset
 
 rustup target add thumbv6m-none-eabi
 
-cargo build --target=thumbv6m-none-eabi --no-default-features
+cargo build --target=thumbv6m-none-eabi


### PR DESCRIPTION
Once Rust `1.42.0` reaches stable we'll be able to publish a stable release of this library.